### PR TITLE
READ.md : Update the package name for Arch Linux (#90)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ bash <(curl -s https://raw.githubusercontent.com/ChristianChiarulli/nvim/master/
 - Arch
 
   ```
-  yay -S neovim-nightly-git # Latest
+  yay -S neovim-git # Latest
   ```
 
 ## Clone this repo into your config


### PR DESCRIPTION
The package 'neovim-git' pulls in the latest source of neovim instead
of the 'neovim-nightly-git' package in the AUR. This will make sure there is no error
related to neovim version on the startup